### PR TITLE
Adds simple Ansible role to deploy httpd.

### DIFF
--- a/ansible-role-httpd/README.md
+++ b/ansible-role-httpd/README.md
@@ -1,0 +1,125 @@
+# Ansible Role: Apache 2.x
+
+An Ansible Role that installs Apache 2.x on RHEL/CentOS/Fedora
+
+## Requirements
+
+If you are using SSL/TLS, you will need to provide your own certificate and key files. You can generate a self-signed certificate with a command like `openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout example.key -out example.crt`.
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+    apache_enablerepo: ""
+
+The repository to use when installing Apache (only used on RHEL/CentOS systems). If you'd like later versions of Apache than are available in the OS's core repositories, use a repository like EPEL (which can be installed with the `geerlingguy.repo-epel` role).
+
+    apache_listen_ip: "*"
+    apache_listen_port: 80
+    apache_listen_port_ssl: 443
+
+The IP address and ports on which apache should be listening. Useful if you have another service (like a reverse proxy) listening on port 80 or 443 and need to change the defaults.
+
+    apache_create_vhosts: true
+    apache_vhosts_filename: "vhosts.conf"
+    apache_vhosts_template: "vhosts.conf.j2"
+
+If set to true, a vhosts file, managed by this role's variables (see below), will be created and placed in the Apache configuration folder. If set to false, you can place your own vhosts file into Apache's configuration folder and skip the convenient (but more basic) one added by this role. You can also override the template used and set a path to your own template, if you need to further customize the layout of your VirtualHosts.
+
+    apache_remove_default_vhost: false
+
+You can add or override global Apache configuration settings in the role-provided vhosts file (assuming `apache_create_vhosts` is true) using this variable. By default it only sets the DirectoryIndex configuration.
+
+    apache_vhosts:
+      # Additional optional properties: 'serveradmin, serveralias, extra_parameters'.
+      - servername: "local.dev"
+        documentroot: "/var/www/html"
+
+Add a set of properties per virtualhost, including `servername` (required), `documentroot` (required), `allow_override` (optional: defaults to the value of `apache_allow_override`), `options` (optional: defaults to the value of `apache_options`), `serveradmin` (optional), `serveralias` (optional) and `extra_parameters` (optional: you can add whatever additional configuration lines you'd like in here).
+
+Here's an example using `extra_parameters` to add a RewriteRule to redirect all requests to the `www.` site:
+
+      - servername: "www.local.dev"
+        serveralias: "local.dev"
+        documentroot: "/var/www/html"
+        extra_parameters: |
+          RewriteCond %{HTTP_HOST} !^www\. [NC]
+          RewriteRule ^(.*)$ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+The `|` denotes a multiline scalar block in YAML, so newlines are preserved in the resulting configuration file output.
+
+    apache_vhosts_ssl: []
+
+No SSL vhosts are configured by default, but you can add them using the same pattern as `apache_vhosts`, with a few additional directives, like the following example:
+
+    apache_vhosts_ssl:
+      - servername: "local.dev"
+        documentroot: "/var/www/html"
+        certificate_file: "/home/vagrant/example.crt"
+        certificate_key_file: "/home/vagrant/example.key"
+        certificate_chain_file: "/path/to/certificate_chain.crt"
+        extra_parameters: |
+          RewriteCond %{HTTP_HOST} !^www\. [NC]
+          RewriteRule ^(.*)$ http://www.%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
+
+Other SSL directives can be managed with other SSL-related role variables.
+
+    apache_ssl_protocol: "All -SSLv2 -SSLv3"
+    apache_ssl_cipher_suite: "AES256+EECDH:AES256+EDH"
+    apache_ignore_missing_ssl_certificate: true
+
+The SSL protocols and cipher suites that are used/allowed when clients make secure connections to your server. These are secure/sane defaults, but for maximum security, performand, and/or compatibility, you may need to adjust these settings.
+
+    apache_allow_override: "All"
+    apache_options: "-Indexes +FollowSymLinks"
+
+If you would like to only create SSL vhosts when the vhost certificate is present (e.g. when using Let’s Encrypt), set `apache_ignore_missing_ssl_certificate` to `false`. When doing this, you might need to run your playbook more than once so all the vhosts are configured (if another part of the playbook generates the SSL certificates).
+
+    apache_ignore_missing_ssl_certificate: true
+
+## .htaccess-based Basic Authorization
+
+If you require Basic Auth support, you can add it either through a custom template, or by adding `extra_parameters` to a VirtualHost configuration, like so:
+
+    extra_parameters: |
+      <Directory "/var/www/password-protected-directory">
+        Require valid-user
+        AuthType Basic
+        AuthName "Please authenticate"
+        AuthUserFile /var/www/password-protected-directory/.htpasswd
+      </Directory>
+
+To password protect everything within a VirtualHost directive, use the `Location` block instead of `Directory`:
+
+    <Location "/">
+      Require valid-user
+      ....
+    </Location>
+
+You would need to generate/upload your own `.htpasswd` file in your own playbook. There may be other roles that support this functionality in a more integrated way.
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+    ---
+    - hosts: httpd_hosts
+      vars:
+        apache_listen_ip: "*"
+        apache_listen_port: 80
+        apache_listen_port_ssl: 443
+        apache_create_vhosts: true
+        apache_vhosts:
+          - {servername: "example.com", documentroot: "/var/www/vhosts/example_com"}
+      roles:
+       - { role: ansible-role-httpd }
+
+## License
+
+MIT / BSD
+
+## Author Information
+
+This role is based on the Ansible Galaxy role: https://github.com/geerlingguy/ansible-role-apache

--- a/ansible-role-httpd/defaults/main.yml
+++ b/ansible-role-httpd/defaults/main.yml
@@ -1,0 +1,51 @@
+---
+apache_enablerepo: ""
+
+apache_listen_ip: "*"
+apache_listen_port: 80
+apache_listen_port_ssl: 443
+
+apache_create_vhosts: true
+apache_vhosts_filename: "vhosts.conf"
+apache_vhosts_template: "vhosts.conf.j2"
+
+apache_global_vhost_settings: |
+  DirectoryIndex index.php index.html
+
+apache_vhosts:
+  # Additional properties:
+  # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
+  - servername: "local.dev"
+    documentroot: "/var/www/html"
+
+apache_allow_override: "All"
+apache_options: "-Indexes +FollowSymLinks"
+
+apache_vhosts_ssl: []
+  # Additional properties:
+  # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
+  # - servername: "local.dev",
+  #   documentroot: "/var/www/html",
+  #   certificate_file: "/path/to/certificate.crt",
+  #   certificate_key_file: "/path/to/certificate.key",
+  #   # Optional.
+  #   certificate_chain_file: "/path/to/certificate_chain.crt"
+
+apache_ignore_missing_ssl_certificate: true
+
+apache_ssl_protocol: "All -SSLv2 -SSLv3"
+apache_ssl_cipher_suite: "AES256+EECDH:AES256+EDH"
+
+# Apache hello world message for index.html
+apache_hello_message_index: "Welcome to the CI/CD Hackathon in the EMEA RHTE 2018!!" 
+
+# Set initial apache state. Recommended values: `started` or `stopped`
+apache_state: started
+
+# Set apache state when configuration changes are made. Recommended values:
+# `restarted` or `reloaded`
+apache_restart_state: restarted
+
+# Apache package state; use `present` to make sure it's installed, or `latest`
+# if you want to upgrade or switch versions using a new repo.
+apache_packages_state: present

--- a/ansible-role-httpd/tasks/configure.yml
+++ b/ansible-role-httpd/tasks/configure.yml
@@ -1,0 +1,34 @@
+---
+- name: Configure httpd.
+  lineinfile:
+    dest: "{{ apache_server_root }}/conf/{{ apache_daemon }}.conf"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    state: present
+  with_items: "{{ apache_ports_configuration_items }}"
+
+- name: Check whether certificates defined in vhosts exist.
+  stat: path={{ item.certificate_file }}
+  register: apache_ssl_certificates
+  with_items: "{{ apache_vhosts_ssl }}"
+
+- name: Add httpd vhosts configuration.
+  template:
+    src: "{{ apache_vhosts_template }}"
+    dest: "{{ apache_conf_path }}/{{ apache_vhosts_filename }}"
+    owner: root
+    group: root
+    mode: 0644
+  when: apache_create_vhosts
+  become: true
+
+- name: Add sample index.html
+  template:
+    src: index.html.j2
+    dest: "{{ item.documentroot }}/index.html"
+    owner: root
+    group: root
+    mode: 0644
+  when: apache_vhosts is defined 
+  with_items: "{{ apache_vhosts }}"
+  become: true

--- a/ansible-role-httpd/tasks/install.yml
+++ b/ansible-role-httpd/tasks/install.yml
@@ -1,0 +1,7 @@
+---
+- name: Install httpd
+  package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ apache_packages }}"
+  become: true

--- a/ansible-role-httpd/tasks/main.yml
+++ b/ansible-role-httpd/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: Define apache_packages.
+  set_fact:
+    apache_packages: "{{ __apache_packages | list }}"
+  when: apache_packages is not defined
+
+# Setup/install tasks.
+- include_tasks: "install.yml"
+
+# Figure out what version of Apache is installed.
+- name: Get installed version of Apache.
+  shell: "{{ apache_daemon_path }}{{ apache_daemon }} -v"
+  changed_when: false
+  check_mode: no
+  register: _apache_version
+
+# Error 1. Typo in the variable
+- name: Create apache_version variable.
+  set_fact:
+    apache_version: "{{ _apache_version_XX.stdout.split()[2].split('/')[1] }}"
+    #apache_version: "{{ _apache_version.stdout.split()[2].split('/')[1] }}"
+
+- include_vars: apache-22.yml
+  when: "apache_version.split('.')[1] == '2'"
+
+- include_vars: apache-24.yml
+  when: "apache_version.split('.')[1] == '4'"
+
+# Configure Apache.
+- include_tasks: "configure.yml"
+
+# Error 2. This task will fail unless id run with 'become: true'
+- name: Ensure httpd is started.
+  systemd:
+    name: "{{ apache_service }}"
+    state: "{{ apache_state }}"
+    enabled: yes
+  become: false
+#  become: true

--- a/ansible-role-httpd/templates/index.html.j2
+++ b/ansible-role-httpd/templates/index.html.j2
@@ -1,0 +1,1 @@
+"{{ apache_hello_message_index }}"

--- a/ansible-role-httpd/templates/vhosts.conf.j2
+++ b/ansible-role-httpd/templates/vhosts.conf.j2
@@ -1,0 +1,82 @@
+{{ apache_global_vhost_settings }}
+
+{# Set up VirtualHosts #}
+{% for vhost in apache_vhosts %}
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}>
+  ServerName {{ vhost.servername }}
+{% if vhost.serveralias is defined %}
+  ServerAlias {{ vhost.serveralias }}
+{% endif %}
+{% if vhost.documentroot is defined %}
+  DocumentRoot "{{ vhost.documentroot }}"
+{% endif %}
+
+{% if vhost.serveradmin is defined %}
+  ServerAdmin {{ vhost.serveradmin }}
+{% endif %}
+{% if vhost.documentroot is defined %}
+  <Directory "{{ vhost.documentroot }}">
+    AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
+    Options {{ vhost.options | default(apache_options) }}
+{% if apache_vhosts_version == "2.2" %}
+    Order allow,deny
+    Allow from all
+{% else %}
+    Require all granted
+{% endif %}
+  </Directory>
+{% endif %}
+{% if vhost.extra_parameters is defined %}
+  {{ vhost.extra_parameters }}
+{% endif %}
+</VirtualHost>
+
+{% endfor %}
+
+{# Set up SSL VirtualHosts #}
+{% for vhost in apache_vhosts_ssl %}
+{% if apache_ignore_missing_ssl_certificate or apache_ssl_certificates.results[loop.index0].stat.exists %}
+<VirtualHost {{ apache_listen_ip }}:{{ apache_listen_port_ssl }}>
+  ServerName {{ vhost.servername }}
+{% if vhost.serveralias is defined %}
+  ServerAlias {{ vhost.serveralias }}
+{% endif %}
+{% if vhost.documentroot is defined %}
+  DocumentRoot "{{ vhost.documentroot }}"
+{% endif %}
+
+  SSLEngine on
+  SSLCipherSuite {{ apache_ssl_cipher_suite }}
+  SSLProtocol {{ apache_ssl_protocol }}
+  SSLHonorCipherOrder On
+{% if apache_vhosts_version == "2.4" %}
+  SSLCompression off
+{% endif %}
+  SSLCertificateFile {{ vhost.certificate_file }}
+  SSLCertificateKeyFile {{ vhost.certificate_key_file }}
+{% if vhost.certificate_chain_file is defined %}
+  SSLCertificateChainFile {{ vhost.certificate_chain_file }}
+{% endif %}
+
+{% if vhost.serveradmin is defined %}
+  ServerAdmin {{ vhost.serveradmin }}
+{% endif %}
+{% if vhost.documentroot is defined %}
+  <Directory "{{ vhost.documentroot }}">
+    AllowOverride {{ vhost.allow_override | default(apache_allow_override) }}
+    Options {{ vhost.options | default(apache_options) }}
+{% if apache_vhosts_version == "2.2" %}
+    Order allow,deny
+    Allow from all
+{% else %}
+    Require all granted
+{% endif %}
+  </Directory>
+{% endif %}
+{% if vhost.extra_parameters is defined %}
+  {{ vhost.extra_parameters }}
+{% endif %}
+</VirtualHost>
+
+{% endif %}
+{% endfor %}

--- a/ansible-role-httpd/tests/test.yml
+++ b/ansible-role-httpd/tests/test.yml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+  vars:
+    apache_listen_port_ssl: 443
+    apache_create_vhosts: true
+    apache_vhosts_filename: "vhosts.conf"
+    apache_vhosts:
+      - servername: "example.com"
+        documentroot: "/var/www/vhosts/example_com"
+  roles:
+    - ansible-role-httpd

--- a/ansible-role-httpd/vars/apache-22.yml
+++ b/ansible-role-httpd/vars/apache-22.yml
@@ -1,0 +1,12 @@
+---
+apache_vhosts_version: "2.2"
+apache_default_vhost_filename: 000-default
+apache_ports_configuration_items:
+  - {
+    regexp: "^Listen ",
+    line: "Listen {{ apache_listen_port }}"
+  }
+  - {
+    regexp: "^#?NameVirtualHost ",
+    line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"
+  }

--- a/ansible-role-httpd/vars/apache-24.yml
+++ b/ansible-role-httpd/vars/apache-24.yml
@@ -1,0 +1,8 @@
+---
+apache_vhosts_version: "2.4"
+apache_default_vhost_filename: 000-default.conf
+apache_ports_configuration_items:
+  - {
+    regexp: "^Listen ",
+    line: "Listen {{ apache_listen_port }}"
+  }

--- a/ansible-role-httpd/vars/main.yml
+++ b/ansible-role-httpd/vars/main.yml
@@ -1,0 +1,21 @@
+---
+apache_service: httpd
+apache_daemon: httpd
+apache_daemon_path: /usr/sbin/
+apache_server_root: /etc/httpd
+apache_conf_path: /etc/httpd/conf.d
+
+apache_vhosts_version: "2.2"
+
+__apache_packages:
+  - httpd
+  - httpd-devel
+  - mod_ssl
+  - openssh
+  - libselinux-python
+
+apache_ports_configuration_items:
+  - regexp: "^Listen "
+    line: "Listen {{ apache_listen_port }}"
+  - regexp: "^#?NameVirtualHost "
+    line: "NameVirtualHost {{ apache_listen_ip }}:{{ apache_listen_port }}"


### PR DESCRIPTION
Tested on Fedora 27 & RHEL 7 (assuming repos already configured)

This role has two errors, can be found in the task/main.yml file,
both errors are documented with a comment.